### PR TITLE
docs: use experiment-action label

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: 🐞 Bug Report
-    url: https://github.com/langfuse/langfuse/issues/new?labels=%F0%9F%90%9E%E2%9D%94+unconfirmed+bug,Experiment+Action&template=bug_report.yml&title=bug(experiment-action)%3A+
+    url: https://github.com/langfuse/langfuse/issues/new?labels=%F0%9F%90%9E%E2%9D%94+unconfirmed+bug,experiment-action&template=bug_report.yml&title=bug(experiment-action)%3A+
     about: Create a bug report to help us improve the Experiment Action.
   - name: 💡 Feature Request
-    url: https://github.com/orgs/langfuse/discussions/new?category=ideas&title=Experiment+Action%3A%20&labels=Experiment+Action
+    url: https://github.com/orgs/langfuse/discussions/new?category=ideas&title=Experiment+Action%3A%20&labels=experiment-action
     about: Suggest any ideas you have using our discussion forums.
   - name: 🤗 Get Help
-    url: https://github.com/orgs/langfuse/discussions/new?category=support&title=Experiment+Action%3A%20&labels=Experiment+Action
+    url: https://github.com/orgs/langfuse/discussions/new?category=support&title=Experiment+Action%3A%20&labels=experiment-action
     about: If you can't get something to work the way you expect, open a question in our discussion forums.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ repository — blank issues on this repo are disabled to keep reporting in
 one place.
 
 - **Bug in the action** or **bug in Langfuse itself (SDK, API, UI)** →
-  open a bug report in `langfuse/langfuse` with the `Experiment Action`
+  open a bug report in `langfuse/langfuse` with the `experiment-action`
   label. The links under "New issue" on this repo route there
   automatically.
 - **Feature requests** → the `ideas` category in


### PR DESCRIPTION
## Summary

- Update all issue/discussion routing links to use the canonical `experiment-action` label instead of `Experiment Action`.
- Document the same `experiment-action` label in README and CONTRIBUTING so contributors use the correct label when filing action-related reports in `langfuse/langfuse`.

## Linear

- None

## Review Focus

- Confirm `experiment-action` is the exact label expected in `langfuse/langfuse` issues and Langfuse discussions.
- Check that the issue/discussion URLs still preserve the intended title prefixes and categories.