### PR TITLE
docs: use shield branding icon

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: "Langfuse Experiment"
 description: "Run a Langfuse experiment in CI, gate on regressions, and comment results on the PR."
 author: "Langfuse"
 branding:
-  icon: "activity"
+  icon: "shield"
   color: "purple"
 
 inputs:


### PR DESCRIPTION
## Summary\n- update the GitHub Action branding icon from `activity` to `shield`\n\n## Verification\n- not run (metadata-only change)