### PR TITLE
ci: adjust zizmor advanced security handling

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,6 +3,7 @@ name: Zizmor
 on:
   push:
     branches: [main]
+  merge_group:
   pull_request:
     branches: [main]
 
@@ -21,3 +22,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: ${{ github.event_name == 'push' && 'true' || 'false' }}
+          min-severity: low


### PR DESCRIPTION
## What changed

- Run `zizmor-action` with `advanced-security: false` for non-`push` events, including pull requests and merge queue runs.
- Keep Advanced Security/SARIF uploads enabled on `push` events.
- Set `min-severity: low` for the zizmor scan.

## Why

Fork pull requests cannot upload code scanning results to GitHub Advanced Security, so requiring zizmor code scanning results blocks community PRs. This keeps the check usable for fork PRs while preserving SARIF upload on trusted pushes.

## Validation

- YAML parse check for `.github/workflows/zizmor.yml`
- `git diff --check -- .github/workflows/zizmor.yml`
