### PR TITLE
ci: assign dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/code-security/reference/supply-chain-security/dependabot-options-reference
 
 version: 2
 updates:
@@ -12,7 +12,7 @@ updates:
     cooldown:
       default-days: 7
     versioning-strategy: "increase"
-    reviewers:
+    assignees:
       - wochinge
     groups:
       npm:
@@ -28,7 +28,7 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-    reviewers:
+    assignees:
       - wochinge
     commit-message:
       prefix: ci


### PR DESCRIPTION
## Summary

- replace unsupported Dependabot `reviewers` entries with `assignees`
- refresh the Dependabot configuration reference link

## Why

Dependabot did not request Tobias for review on dependency update PRs. GitHub's current Dependabot configuration supports automatic assignees in `dependabot.yml`; reviewer routing should use CODEOWNERS instead.

## Validation

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run check:schema`
