### PR TITLE
ci: add maintainer-triggered dist update workflow

### DIFF
--- a/.github/workflows/update-dist-on-label.yml
+++ b/.github/workflows/update-dist-on-label.yml
@@ -50,8 +50,18 @@ jobs:
       - name: Validate generated changes
         id: validate
         run: |
-          changed_files="$(git status --porcelain --untracked-files=all | sed -E 's/^...//')"
-          non_dist_files="$(printf '%s\n' "$changed_files" | grep -v '^dist/' || true)"
+          changed_files=""
+          non_dist_files=""
+
+          while IFS= read -r -d '' entry; do
+            path="${entry:3}"
+            changed_files+="${path}"$'\n'
+
+            case "$path" in
+              dist/*) ;;
+              *) non_dist_files+="${path}"$'\n' ;;
+            esac
+          done < <(git status --porcelain=v1 -z --untracked-files=all --no-renames)
 
           if [ -n "$non_dist_files" ]; then
             echo "::error::The dist update changed files outside dist/:"

--- a/.github/workflows/update-dist-on-label.yml
+++ b/.github/workflows/update-dist-on-label.yml
@@ -1,0 +1,95 @@
+name: Update dist on label
+
+on:
+  pull_request:
+    branches: [main]
+    types: [labeled]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-dist-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "24"
+
+jobs:
+  update-dist:
+    name: Rebuild and commit dist/
+    runs-on: ubuntu-latest
+    # Maintainers opt in by applying the label. Keep this to same-repo
+    # Dependabot PRs so the write token is not exposed to arbitrary PR code.
+    # User id 49699333 is dependabot[bot].
+    if: >
+      github.event.label.name == 'update-dist' &&
+      github.event.pull_request.user.id == 49699333 &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          package-manager-cache: false
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Rebuild bundle
+        run: pnpm run build
+
+      - name: Validate generated changes
+        id: validate
+        run: |
+          changed_files="$(git status --porcelain --untracked-files=all | sed -E 's/^...//')"
+          non_dist_files="$(printf '%s\n' "$changed_files" | grep -v '^dist/' || true)"
+
+          if [ -n "$non_dist_files" ]; then
+            echo "::error::The dist update changed files outside dist/:"
+            printf '%s\n' "$non_dist_files"
+            exit 1
+          fi
+
+          if [ -z "$changed_files" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit dist update
+        if: steps.validate.outputs.has_changes == 'true'
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git fetch origin "$HEAD_REF"
+          current_head="$(git rev-parse FETCH_HEAD)"
+
+          if [ "$current_head" != "$HEAD_SHA" ]; then
+            echo "::error::PR head moved while rebuilding dist/. Reapply the label to retry."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add dist
+          git commit -m "chore(deps): update dist"
+
+      - name: Push dist update
+        if: steps.validate.outputs.has_changes == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${HEAD_REF}"

--- a/.github/workflows/update-dist-on-label.yml
+++ b/.github/workflows/update-dist-on-label.yml
@@ -99,7 +99,12 @@ jobs:
       - name: Push dist update
         if: steps.validate.outputs.has_changes == 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          DIST_UPDATE_PAT: ${{ secrets.DIST_UPDATE_PAT }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${HEAD_REF}"
+          if [ -z "$DIST_UPDATE_PAT" ]; then
+            echo "::error::Missing DIST_UPDATE_PAT secret. Use a classic PAT with public_repo scope."
+            exit 1
+          fi
+
+          git push "https://x-access-token:${DIST_UPDATE_PAT}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${HEAD_REF}"


### PR DESCRIPTION
## What changed

Adds an `Update dist on label` workflow that lets a maintainer apply the `update-dist` label to same-repo Dependabot PRs to rebuild and commit `dist/`.

The workflow intentionally uses `pull_request` `labeled`, not `pull_request_target`.

## Guardrails

- only runs when the applied label is `update-dist`
- only runs for `dependabot[bot]` by GitHub user id `49699333`
- only runs for same-repo PRs
- checks out the exact PR head SHA with `persist-credentials: false`
- validates that generated changes are limited to `dist/**`
- verifies the PR head did not move before committing

## Verification

- `actionlint .github/workflows/update-dist-on-label.yml`
- `pnpm exec prettier --check .github/workflows/update-dist-on-label.yml`
- pre-commit hook passed: build, lint, typecheck, format check, schema check