### PR TITLE
ci: harden dist update workflow

### DIFF
--- a/.github/workflows/update-dist-on-label.yml
+++ b/.github/workflows/update-dist-on-label.yml
@@ -6,7 +6,7 @@ on:
     types: [labeled]
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: update-dist-${{ github.event.pull_request.number }}
@@ -94,7 +94,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git add dist
-          git commit -m "chore(deps): update dist"
+          git commit --no-verify -m "chore(deps): update dist"
 
       - name: Push dist update
         if: steps.validate.outputs.has_changes == 'true'


### PR DESCRIPTION
## What changed

Follow-up to #52 addressing Claude review feedback from https://github.com/langfuse/experiment-action/pull/52#pullrequestreview-4409225078.

- Lower the workflow's default `GITHUB_TOKEN` permission from `contents: write` to `contents: read`, since pushing uses `secrets.DIST_UPDATE_PAT`.
- Use `git commit --no-verify` for the workflow-generated dist commit so the runner does not invoke Husky's local pre-commit hook after the workflow already rebuilt and validated `dist/`.

## Verification

- `actionlint .github/workflows/update-dist-on-label.yml`
- `pnpm exec prettier --check .github/workflows/update-dist-on-label.yml`
- pre-commit hook passed: build, lint, typecheck, format check, schema check