### PR TITLE
chore(deps): block TypeScript 7.0.x dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,12 @@ updates:
     versioning-strategy: "increase"
     assignees:
       - wochinge
+    ignore:
+      # TypeScript 7.0.x ships as the native/Go compiler rewrite and breaks
+      # typescript-eslint and the dist/ build (ncc). Unblock once 7.1 lands
+      # the API that restores typescript-eslint support.
+      - dependency-name: "typescript"
+        versions: [">= 7.0.0, < 7.1.0"]
     groups:
       npm:
         patterns:


### PR DESCRIPTION
Blocks Dependabot from proposing TypeScript 7.0.x (see #132): that range is Microsoft's native/Go compiler rewrite, not the classic JS compiler, and it breaks `typescript-eslint` (unsupported) and the `dist/` build (`@vercel/ncc`'s TS loader throws `Cannot read properties of undefined (reading 'fileExists')`).

Scoped to `>= 7.0.0, < 7.1.0` only, so Dependabot can propose 7.1 once it ships the API that restores `typescript-eslint` support.

Closes the currently-open #132 (typescript 6.0.3 -> 7.0.2), which fails CI for the reasons above.